### PR TITLE
Add support for page-specific extra scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ If you add a key of `show_reading_time` true to either the Config Params, a page
 Some scripts need to be added within the page head. To add your own scripts to the page head, simply insert them into the `head-additions.html` partial located in the `layouts/partials` folder.
 
 
+### Adding Scripts to Specific Pages
+
+Some pages may require extra scripts (e.g. for showing a map or a slider animation).
+These can be specified by setting the `page_scripts` value in the front matter.
+Its keys `sync` and `async` may contain lists of script locations.
+
+```
+title: foo
+page_scripts:
+  sync:
+    - /js/foo.js
+    - /js/bar.js
+  async:
+    - /js/baz.js
+```
+
+
 ### Logo
 
 You can replace the title of your site in the top left corner of each page with your own logo. To do that put your own logo into the `static` directory of your website, and add the `site_logo` parameter to the site params in your config file. For example:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -52,6 +52,6 @@
       {{ block "main" . }}{{ end }}
     </main>
     {{ block "footer" . }}{{ partialCached "site-footer.html" . }}{{ end }}
-    {{ block "scripts" . }}{{ partialCached "site-scripts.html" . }}{{ end }}
+    {{ block "scripts" . }}{{ partialCached "site-scripts.html" . (default "" .Params.page_scripts) }}{{ end }}
   </body>
 </html>

--- a/layouts/partials/site-scripts.html
+++ b/layouts/partials/site-scripts.html
@@ -2,3 +2,9 @@
 {{ with $script.js }}
   <script src="{{ relURL (printf "%s%s" "dist/" .) }}"></script>
 {{ end }}
+{{ range .Params.page_scripts.sync }}
+  <script src="{{ relURL (.) }}"></script>
+{{ end }}
+{{ range .Params.page_scripts.async }}
+  <script async src="{{ relURL (.) }}"></script>
+{{ end }}


### PR DESCRIPTION
The new front matter variable `page_scripts` allows to specify
javascript ressources to be loaded in sync or async mode.
This allows javascript code to be loaded, that is only required for a
small set of pages (e.g. showing a map or a slider animation).

