### PR TITLE
Fix '+' character being written as &#43;

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -30,7 +30,7 @@
       </p>
       {{ end }}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
-      <time class="f6 mv4 dib tracked" datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
+      <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>
         {{- .Date.Format "January 2, 2006" -}}
       </time>
 


### PR DESCRIPTION
The existing template code results in the + chartering being written in a form that is not valid for the datetime element when used in and <time> tag.

This patch fixes this issue.
references:
https://discourse.gohugo.io/t/date-lastmod-return-43-in-place-of/27033
https://github.com/gohugoio/hugo/issues/7488