### PR TITLE
use RelPermalink for i18n menu

### DIFF
--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -3,7 +3,7 @@
 <ul class="pl0 mr3">
     {{ range .Translations }}
     <li class="list f5 f4-ns fw4 dib pr3">
-        <a class="hover-white no-underline white-90" href="{{ .Permalink }}">{{ .Lang }}</a>
+        <a class="hover-white no-underline white-90" href="{{ .RelPermalink }}">{{ .Lang }}</a>
     </li>
     {{ end}}
 </ul>


### PR DESCRIPTION
When not using the configured URL then this breaks (e.g. using branch/PR deployments on netlify).