### PR TITLE
Fix: Featured image requires absolute path #233

### DIFF
--- a/layouts/partials/func/GetFeaturedImage.html
+++ b/layouts/partials/func/GetFeaturedImage.html
@@ -18,13 +18,21 @@
 {{/* Declare a new string variable, $linkToCover */}}
 {{ $linkToCover := "" }}
 
+{{/* Declare a new string variable, $img, if this is an image resource */}}
+{{ $img := "" }}
+
 {{/* Use the value from front matter if present */}}
 {{ if .Params.featured_image }}
-    {{ $linkToCover = .Params.featured_image }}
-
+    {{ $img = (.Resources.ByType "image").GetMatch .Params.featured_image }}
+    {{ if not $img }}
+        {{ $linkToCover = .Params.featured_image }}
+    {{ end }}
 {{/* Find the first image with 'cover' in the name in this page bundle. */}}
 {{ else }}
-    {{ $img := (.Resources.ByType "image").GetMatch "*cover*" }}
+    {{ $img = (.Resources.ByType "image").GetMatch "*cover*" }}
+{{ end }}
+
+{{ if not $linkToCover }}
     {{ with $img }}
         {{ $linkToCover = .Permalink }}
     {{ end }}


### PR DESCRIPTION
This fixes #233 

I have one hesitation: `func/GetFeaturedImage`  that this modifies is called from 3 files:

* layouts/post/summary-with-image.html
* layouts/partials/page-header.html
* layouts/partials/summary-with-image.html

As you can see there is both a `summary-with-image.html` in `post/` and `partials/`. I was not able to find any reference to `post/summary-with-image.html` though, so I was not able to test that code-path. I could only see `partials/summary-with-image.html` being called:

```
me@machine:~/some/path/themes/ananke» ack summary-with-image
layouts/index.html:29:            {{ partial "summary-with-image.html" . }}
```

In my setup, everything worked fine even if `post/summary-with-image.html` is deleted entirely... So some help in how to setup something up that actually uses `post/summary-with-image.html` would be appreciated. But I don't (yet) see why it shouldn't work there also.