### PR TITLE
enable hosting the website also on other URLs

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,7 +37,7 @@
         {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first" on the outside */}}
         {{ range (first 4 (after $n_posts $section))  }}
           <h2 class="f5 fw4 mb4 dib mr3">
-            <a href="{{ .Permalink }}" class="link black dim">
+            <a href="{{ .RelPermalink }}" class="link black dim">
               {{ .Title }}
             </a>
           </h2>
@@ -45,7 +45,7 @@
 
         {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
         {{ with .Site.GetPage "section" $section_name }}
-          <a href="{{ .Permalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
+          <a href="{{ .RelPermalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
         {{ end }}
         </section>
       {{ end }}

--- a/layouts/partials/func/GetFeaturedImage.html
+++ b/layouts/partials/func/GetFeaturedImage.html
@@ -1,8 +1,8 @@
 {{/* 
     GetFeaturedImage
 
-    This partial gets the url for featured image for a given page. 
-    
+    This partial gets the url for featured image for a given page.
+
     If a featured_image was set in the page's front matter, then that will be used.
 
     If not set, this will search page resources to find an image that contains the word
@@ -11,7 +11,7 @@
     If no featured_image was set, and there's no "cover" image in page resources, then
     this partial returns an empty string (which evaluates to false).
 
-    @return Permalink to featured image, or an empty string if not found.
+    @return RelPermalink to featured image, or an empty string if not found.
 
 */}}
 
@@ -26,7 +26,7 @@
 {{ else }}
     {{ $img := (.Resources.ByType "image").GetMatch "*cover*" }}
     {{ with $img }}
-        {{ $linkToCover = .Permalink }}
+        {{ $linkToCover = .RelPermalink }}
     {{ end }}
 {{ end }}
 

--- a/layouts/partials/social-share.html
+++ b/layouts/partials/social-share.html
@@ -1,5 +1,5 @@
 {{ $title := .Title }}
-{{ $url := printf "%s" .Permalink | absLangURL }}
+{{ $url := printf "%s" .RelPermalink | absLangURL }}
 {{ $icon_size := "32px" }}
 
 {{ if not .Params.disable_share }}

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -6,21 +6,21 @@
           {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
         {{ $featured_image := (trim $featured_image "/") | absURL }}
         <div class="pr3-ns mb4 mb0-ns w-100 w-40-ns">
-          <a href="{{.Permalink}}" class="db grow">
+          <a href="{{.RelPermalink}}" class="db grow">
             <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}">
           </a>
         </div>
       {{ end }}
       <div class="blah w-100{{ if $featured_image }} w-60-ns pl3-ns{{ end }}">
         <h1 class="f3 fw1 athelas mt0 lh-title">
-          <a href="{{.Permalink}}" class="color-inherit dim link">
+          <a href="{{.RelPermalink}}" class="color-inherit dim link">
             {{ .Title }}
             </a>
         </h1>
         <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
           {{ .Summary }}
         </div>
-          <a href="{{.Permalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
+          <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
         {{/* TODO: add author
         <p class="f6 lh-copy mv0">By {{ .Author }}</p> */}}
       </div>

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -2,7 +2,7 @@
   <div class="bg-white mb3 pa4 gray overflow-hidden">
     <span class="f6 db">{{ humanize .Section }}</span>
     <h1 class="f3 near-black">
-      <a href="{{ .Permalink }}" class="link black dim">
+      <a href="{{ .RelPermalink }}" class="link black dim">
         {{ .Title }}
       </a>
     </h1>

--- a/layouts/post/summary-with-image.html
+++ b/layouts/post/summary-with-image.html
@@ -1,5 +1,5 @@
 <article class="bb b--black-10">
-  <a class="db pv4 ph3 ph0-l no-underline dark-gray dim" href="{{ .Permalink }}">
+  <a class="db pv4 ph3 ph0-l no-underline dark-gray dim" href="{{ .RelPermalink }}">
     <div class="flex flex-column flex-row-ns">
       {{ $featured_image := partial "func/GetFeaturedImage.html" . }}
       {{ if $featured_image }}

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -5,7 +5,7 @@
       </div>
     {{ end }}
     <h1 class="f3 near-black">
-      <a href="{{ .Permalink }}" class="link black dim">
+      <a href="{{ .RelPermalink }}" class="link black dim">
         {{ .Title }}
       </a>
     </h1>


### PR DESCRIPTION
I just submitted a PR for the language picker to have relative URLs because that was a thing I was working on then. I just recently found that other sections are also using the Permalink.

This PR replaces all usage of `.Permalink` with `.RelPermalink`. I setup a test website for this here: https://5f88ad34a2750b00077a188b--janxyz.netlify.app

Without the change references like links to Posts would point to the production version on `jan-steinke.de` and that was annoying to test new things as URLs needed manual intervention. This should fix that problem.

