### PR TITLE
Fix confusion in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Also includes examples of Hugo Features or Functions:
 - `where`
 - Content Views
 - Partials
-- Template layouts (type "post" uses a special list template, single template,  and a content view)
+- Template layouts (type "post" uses a special list template, single template, and a content view)
 - Tags
 - `len`
 - Conditionals
@@ -51,12 +51,17 @@ This theme uses the "Tachyons" CSS library. This will allow you to manipulate th
 
 ### As a Hugo Module (recommended)
 
-Simply add the repo to your theme option:
+1. Initiate the hugo module system:
 
-```yaml
-theme:
-  - github.com/theNewDynamic/gohugo-theme-ananke
-```
+   ```
+   $ hugo mod init github.com/<your_user>/<your_project>
+   ```
+
+2. Add the theme in your `config.toml`:
+
+   ```toml
+   theme = ["github.com/theNewDynamic/gohugo-theme-ananke"]
+   ```
 
 ### As Git Submodule
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This theme uses the "Tachyons" CSS library. This will allow you to manipulate th
    $ hugo mod init github.com/<your_user>/<your_project>
    ```
 
-2. Add the theme in your `config.toml`:
+2. Add the theme's repo to your `config.toml`:
 
    ```toml
    theme = ["github.com/theNewDynamic/gohugo-theme-ananke"]


### PR DESCRIPTION
~~The user's module system may not be initialised. It should be initialised first, otherwise the user will be prompt with:~~
```
Error: module "github.com/theNewDynamic/gohugo-theme-ananke" not found; either add it as a Hugo Module or store it in "/path/to/dir/themes".: module does not exist
```
The above issue has been fixed by ce48112de29f91330ec4da2bfb7ed14d0ee1a19f, the PR has been updated.

The code snippet did not specify that yaml syntax was used instead of the default toml syntax. Changed it to toml syntax to avoid confusion.