### PR TITLE
ranged through an array to make social-follow.html more efficient

### DIFF
--- a/layouts/partials/social-follow.html
+++ b/layouts/partials/social-follow.html
@@ -5,7 +5,7 @@
 
 {{ range $social_media }}
   {{ $this_key := . }}
-  {{ with $dot_passthrough.Param . }}
+  {{ with $dot_passthrough.Param ( . | lower ) }}
   <a href="{{ . }}" target="_blank" class="link-transition {{ $this_key | lower }} link dib z-999 pt3 pt0-l mr1" title="{{ $this_key }} link" rel="noopener" aria-label="follow on {{ $this_key }}——Opens in a new window">
     {{ partial (print "svg/" ($this_key | lower) ".svg") (dict "size" $icon_size) }}
     {{- partial "new-window-icon.html" . -}}

--- a/layouts/partials/social-follow.html
+++ b/layouts/partials/social-follow.html
@@ -1,80 +1,14 @@
 <!-- TODO: Add follow intents where available TODO: Revisit color and hover color -->
 {{ $icon_size := "32px" }}
-{{ with .Param "stackoverflow" }}
-<a href="{{ . }}" target="_blank" class="link-transition stackoverflow link dib z-999 pt3 pt0-l mr1" title="Stack Overflow link" rel="noopener" aria-label="follow on Stack Overflow——Opens in a new window">
-  {{ partial "svg/stackoverflow.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "facebook" }}
-<a href="{{ . }}" target="_blank" class="link-transition facebook link dib z-999 pt3 pt0-l mr1" title="Facebook link" rel="noopener" aria-label="follow on Facebook——Opens in a new window">
-  {{ partial "svg/facebook.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "twitter" }}
-<a href="{{ . }}" target="_blank" class="link-transition twitter link dib z-999 pt3 pt0-l mr1" title="Twitter link" rel="noopener" aria-label="follow on Twitter——Opens in a new window">
-  {{ partial "svg/twitter.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "instagram" }}
-<a href="{{ . }}" target="_blank" class="link-transition instagram link dib z-999 pt3 pt0-l mr1" title="Instagram link" rel="noopener" aria-label="follow on Instagram——Opens in a new window">
-  {{ partial "svg/instagram.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "youtube" }}
-<a href="{{ . }}" target="_blank" class="link-transition youtube link dib z-999 pt3 pt0-l mr1" title="Youtube link" rel="noopener" aria-label="follow on Youtube——Opens in a new window">
-  {{ partial "svg/youtube.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "linkedin" }}
-<a href="{{ . }}" target="_blank" class="link-transition linkedin link dib z-999 pt3 pt0-l mr1" title="LinkedIn link" rel="noopener" aria-label="follow on LinkedIn——Opens in a new window">
-  {{ partial "svg/linkedin.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "github" }}
-<a href="{{ . }}" target="_blank" class="link-transition github link dib z-999 pt3 pt0-l mr1" title="Github link" rel="noopener" aria-label="follow on Github——Opens in a new window">
-  {{ partial "svg/github.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "gitlab" }}
-<a href="{{ . }}" target="_blank" class="link-transition gitlab link dib z-999 pt3 pt0-l mr1" title="Gitlab link" rel="noopener" aria-label="follow on Gitlab——Opens in a new window">
-  {{ partial "svg/gitlab.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "keybase" }}
-<a href="{{ . }}" target="_blank" class="link-transition keybase link dib z-999 pt3 pt0-l mr1" title="Keybase link" rel="noopener" aria-label="follow on Keybase——Opens in a new window">
-  {{ partial "svg/keybase.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "medium" }}
-<a href="{{ . }}" target="_blank" class="link-transition medium link dib z-999 pt3 pt0-l mr1" title="Medium link" rel="noopener" aria-label="follow on Medium——Opens in a new window">
-  {{ partial "svg/medium.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "mastodon" }}
-<a href="{{ . }}" target="_blank" class="link-transition mastodon link dib z-999 pt3 pt0-l mr1" title="Mastodon link" rel="noopener" aria-label="follow on Mastodon——Opens in a new window">
-  {{ partial "svg/mastodon.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "slack" }}
-<a href="{{ . }}" target="_blank" class="link-transition slack link dib z-999 pt3 pt0-l mr1" title="Slack link" rel="noopener" aria-label="follow on Slack——Opens in a new window">
-  {{ partial "svg/slack.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
-{{ end }}
-{{ with .Param "rss" }}
-<a href="{{ . }}" target="_blank" class="link-transition rss link dib z-999 pt3 pt0-l mr1" title="RSS link" rel="noopener" aria-label="RSS——Opens in a new window">
-  {{ partial "svg/rss.svg" (dict "size" $icon_size) }}
-  {{- partial "new-window-icon.html" . -}}
-</a>
+{{ $social_media := slice "stackoverflow" "facebook" "twitter" "instagram" "youtube" "linkedin" "github" "gitlab" "keybase" "medium" "mastodon" "slack" "rss" }}
+{{ $dot_passthrough := . }}
+
+{{ range $social_media }}
+  {{ $this_key := . }}
+  {{ with $dot_passthrough.Param . }}
+  <a href="{{ . }}" target="_blank" class="link-transition {{ $this_key }} link dib z-999 pt3 pt0-l mr1" title="{{ $this_key | humanize}} link" rel="noopener" aria-label="follow on {{ $this_key | humanize}}——Opens in a new window">
+    {{ partial (print "svg/" $this_key ".svg") (dict "size" $icon_size) }}
+    {{- partial "new-window-icon.html" . -}}
+  </a>
+  {{ end }}
 {{ end }}

--- a/layouts/partials/social-follow.html
+++ b/layouts/partials/social-follow.html
@@ -1,13 +1,13 @@
 <!-- TODO: Add follow intents where available TODO: Revisit color and hover color -->
 {{ $icon_size := "32px" }}
-{{ $social_media := slice "stackoverflow" "facebook" "twitter" "instagram" "youtube" "linkedin" "github" "gitlab" "keybase" "medium" "mastodon" "slack" "rss" }}
+{{ $social_media := slice "StackOverflow" "Facebook" "Twitter" "Instagram" "YouTube" "LinkedIn" "GitHub" "GitLab" "Keybase" "Medium" "Mastodon" "Slack" "RSS" }}
 {{ $dot_passthrough := . }}
 
 {{ range $social_media }}
   {{ $this_key := . }}
   {{ with $dot_passthrough.Param . }}
-  <a href="{{ . }}" target="_blank" class="link-transition {{ $this_key }} link dib z-999 pt3 pt0-l mr1" title="{{ $this_key | humanize}} link" rel="noopener" aria-label="follow on {{ $this_key | humanize}}——Opens in a new window">
-    {{ partial (print "svg/" $this_key ".svg") (dict "size" $icon_size) }}
+  <a href="{{ . }}" target="_blank" class="link-transition {{ $this_key | lower }} link dib z-999 pt3 pt0-l mr1" title="{{ $this_key }} link" rel="noopener" aria-label="follow on {{ $this_key }}——Opens in a new window">
+    {{ partial (print "svg/" ($this_key | lower) ".svg") (dict "size" $icon_size) }}
     {{- partial "new-window-icon.html" . -}}
   </a>
   {{ end }}


### PR DESCRIPTION
not sure if this is helpful, but I made the `social-follow.html` more succinct by ranging through all of the repetitive code.

This could probably be improved by making sure the `title` and `aria-label` attributes are correctly capitalized for each link.  I used `humanize` to try to achieve this, but it does not split 'Stack Overflow' into two words or correctly capitalize 'LinkedIn.'

