### PR TITLE
fix: do not render a date if it is not set

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -29,10 +29,12 @@
           </strong>
       </p>
       {{ end }}
-      {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
+      {{/* Hugo uses Go's date formatting is set by example. Here are two formats. */}}
+      {{ if .Date }}
       <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>
         {{- .Date.Format "January 2, 2006" -}}
       </time>
+      {{ end }}
 
       {{/*
           Show "reading time" and "word count" but only if one of the following are true:


### PR DESCRIPTION
Fixes the issue where content without a date set render a date of "January 1, 0001".

As shown here:
![image](https://user-images.githubusercontent.com/4665045/103656017-fd97bf00-4f5f-11eb-90af-2dda86f9ac5e.png)

Hopefully this is acceptable, I aimed for this to do the same as was done here:
https://github.com/theNewDynamic/gohugo-theme-ananke/blob/f5cdf1f3a6ce58040dba752b684988e7251c2e37/layouts/post/summary.html#L2-L6

