### PR TITLE
Transform the robots meta tag to lowercase (closes #378)

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,9 +10,9 @@
     {{ hugo.Generator }}
     {{/* NOTE: For Production make sure you add `HUGO_ENV="production"` before your build command */}}
     {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
-      <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
+      <meta name="robots" content="index, follow">
     {{ else }}
-      <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+      <meta name="robots" content="noindex, nofollow">
     {{ end }}
 
     {{ $stylesheet := .Site.Data.webpack_assets.app }}


### PR DESCRIPTION
This PR transforms the robots meta tag to lowercase as browsers parse and display them only in lowercase.

