### PR TITLE
Update site-navigation.html

### DIFF
--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -1,6 +1,6 @@
 <nav class="pv3 ph3 ph4-ns" role="navigation">
   <div class="flex-l justify-between items-center center">
-    <a href="{{ .Site.Home.RelPermalink }}" class="f3 fw2 hover-white no-underline white-90 dib">
+    <a href="{{ .Site.BaseURL }}" class="f3 fw2 hover-white no-underline white-90 dib">
       {{ with .Site.Params.site_logo }}
         <img src="{{ . }}" class="w100 mw5-ns" alt="{{ $.Site.Title }}" />
       {{ else }}


### PR DESCRIPTION
Using `disableKinds = ["home"]` is causing the loss of the `.Site.Home.RelPermalink` variable, which is the href link used in the site-navigation page. Without it, clicking on the site logo no longer links to the homepage. Using `.Site.BaseURL` instead hopefully addresses the issue.

