### PR TITLE
Only print article date if it is non-zero

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -30,9 +30,11 @@
       </p>
       {{ end }}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
+      {{ if not .Date.IsZero }}
       <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>
         {{- .Date.Format "January 2, 2006" -}}
       </time>
+      {{end}}
 
       {{/*
           Show "reading time" and "word count" but only if one of the following are true:


### PR DESCRIPTION
The current template that parses articles will set a date of January 1, 0001 if the date is not defined in the md file. This PR wraps the date template in a conditional to check if the date has been set. If the date is not set the template will render the article without a date.

