### PR TITLE
fix : production should Allow and point to Sitemap

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,7 +1,8 @@
 User-agent: *
 # robotstxt.org - if ENV production variable is false robots will be disallowed.
 {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
-  Disallow:
+Allow: /
+Sitemap: {{.Site.BaseURL}}/sitemap.xml
 {{ else }}
-  Disallow: /
+Disallow: /
 {{ end }}


### PR DESCRIPTION
My understanding of how **robots.txt** are interpreted by search engines is that they should be explicitly *allowed* to parse the site ([source](https://developers.google.com/search/docs/advanced/robots/robots_txt?hl=en#allow)). Moreover, Google, Bing uses the `sitemap` entry in **robots.txt**. Here, the path is assembled with `{{.Site.BaseURL}}`