### PR TITLE
Changes .GetMatch Pattern to find bundled assets

### DIFF
--- a/layouts/partials/func/GetFeaturedImage.html
+++ b/layouts/partials/func/GetFeaturedImage.html
@@ -24,7 +24,7 @@
 
 {{/* Find the first image with 'cover' in the name in this page bundle. */}}
 {{ else }}
-    {{ $img := (.Resources.ByType "image").GetMatch "*cover*" }}
+    {{ $img := (.Resources.ByType "image").GetMatch "**/*cover*" }}
     {{ with $img }}
         {{ $linkToCover = .Permalink }}
     {{ end }}


### PR DESCRIPTION
When I attempted to use `func/GetFeaturedImage.html`, it did not find my resource, `images/foo-cover.webp`. Updating the match syntax to the pattern expressed here, provided expected behavior:

Per:

https://gohugo.io/content-management/page-resources/#pattern-matching

> .Resources.Match "*sunset.jpg" 🚫

and...

> .Resources.Match "*" 🚫

Are not expected to work

> .Resources.Match "**/sunset.jpg" ✅

which follows this change, does.