### PR TITLE
chore: make site description visible as intended

### DIFF
--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -8,7 +8,7 @@
       <div class="tc-l pv6 ph3 ph4-ns">
         {{ if not .Params.omit_header_text }}
           <h1 class="f2 f1-l fw2 white-90 mb0 lh-title">{{ .Title | default .Site.Title }}</h1>
-          {{ with .Site.Params.description  }}
+          {{ with .Site.Params.description }}
             <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
               {{ . }}
             </h2>

--- a/layouts/partials/page-header.html
+++ b/layouts/partials/page-header.html
@@ -8,7 +8,7 @@
       <div class="tc-l pv6 ph3 ph4-ns">
         {{ if not .Params.omit_header_text }}
           <h1 class="f2 f1-l fw2 white-90 mb0 lh-title">{{ .Title | default .Site.Title }}</h1>
-          {{ with .Params.description  }}
+          {{ with .Site.Params.description  }}
             <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
               {{ . }}
             </h2>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -9,7 +9,7 @@
         <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
           {{ .Title | default .Site.Title }}
         </h1>
-        {{ with .Params.description }}
+        {{ with .Site.Params.description }}
           <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3">
             {{ . }}
           </h2>
@@ -25,7 +25,7 @@
         <h1 class="f2 f-subheadline-l fw2 light-silver mb0 lh-title">
           {{ .Title | default .Site.Title }}
         </h1>
-        {{ with .Params.description }}
+        {{ with .Site.Params.description }}
           <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
             {{ . }}
           </h2>


### PR DESCRIPTION
I have the same issue as @corch here https://github.com/theNewDynamic/gohugo-theme-ananke/issues/238

`.Params.description` gets ignored by the header templates while `.Site.Params.description` works indeed.