### PR TITLE
Base content title on ContentBaseName

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,5 @@
 ---
-title: "{{ replace .TranslationBaseName "-" " " | title }}"
+title: "{{ replace .File.ContentBaseName "-" " " | title }}"
 date: {{ .Date }}
 tags: []
 featured_image: ""


### PR DESCRIPTION
With Hugo v0.88.1 and earlier, ContentBaseName and TranslationBaseName
both returned "index" when creating a leaf bundle with hugo new. This is
a known bug, addressed with https://github.com/gohugoio/hugo/pull/9045.

With this PR:

  hugo new post/my-first-post/index.md

will produce:

  title: "My First Post"

instead of:

  title: "Index"