### PR TITLE
Featured image detection refactoring:

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ To enable comments, add following to your config file:
 
 For any page or post you can add a featured image by including the local path in front matter (see content in the `exampleSite/content/_readme.md` file for examples): `featured_image: '/images/gohugo-default-sample-hero-image.jpg'`
 
+#### Featured image as Page Resources
+If user is using [Page Resources](https://gohugo.io/content-management/page-resources/), the theme will try and match the `featured_image` from with a page resource of type `image` and use its relative permalink. If no `featured_image` is set, the theme will look for a Page Resource of type `image` whose filepath incudes either `cover` or `feature` 
+
+#### Other hero settings
 If you would like to hide the header text on the featured image on a page, set `omit_header_text` to `true`. See `exampleSite/content/contact.md` for an example.
 
 You don't need an image though. The default background color is black, but you can change the color, by changing the default color class in the config.toml file. Choose a background color from any on the [Tachyons](http://tachyons.io/docs/themes/skins/) library site, and preface it with "bg-"

--- a/layouts/partials/func/GetFeaturedImage.html
+++ b/layouts/partials/func/GetFeaturedImage.html
@@ -1,33 +1,37 @@
 {{/* 
-    GetFeaturedImage
+	GetFeaturedImage
 
-    This partial gets the url for featured image for a given page.
+	This partial gets the url for featured image for a given page.
 
-    If a featured_image was set in the page's front matter, then that will be used.
+	If a featured_image was set in the page's front matter, then that will be used.
 
-    If not set, this will search page resources to find an image that contains the word
-    "cover", and if found, returns the path to that resource.
+	If not set, this will search page resources to find an image that contains the word
+	"cover", and if found, returns the path to that resource.
 
-    If no featured_image was set, and there's no "cover" image in page resources, then
-    this partial returns an empty string (which evaluates to false).
+	If no featured_image was set, and there's no "cover" image in page resources, then
+	this partial returns an empty string (which evaluates to false).
 
-    @return RelPermalink to featured image, or an empty string if not found.
+	@return RelPermalink to featured image, or an empty string if not found.
 
 */}}
 
 {{/* Declare a new string variable, $linkToCover */}}
 {{ $linkToCover := "" }}
-
+{{ $matches := "feature,cover" }}
 {{/* Use the value from front matter if present */}}
-{{ if .Params.featured_image }}
-    {{ $linkToCover = .Params.featured_image }}
-
+{{ with .Params.featured_image }}
+	{{ $linkToCover = . }}
+  {{/* If we find a Page Resource matching the exact value, we use it instead. */}}
+  {{ with $.Resources.GetMatch . }}
+    {{ $linkToCover = .RelPermalink }}
+  {{ end }}
 {{/* Find the first image with 'cover' in the name in this page bundle. */}}
 {{ else }}
-    {{ $img := (.Resources.ByType "image").GetMatch "*cover*" }}
-    {{ with $img }}
-        {{ $linkToCover = .RelPermalink }}
+  {{ with .Resources.ByType "image" }}
+    {{ with .GetMatch (printf "**{%s}*" $matches) }}
+      {{ $linkToCover = .RelPermalink }}
     {{ end }}
+  {{ end }}
 {{ end }}
 
 {{/* return either a permalink, or an empty string. Note that partials can only have a single


### PR DESCRIPTION
We look for .Params.featured_image
If found > we use that as URL
If we find a Page resource matching the value of the above, we use its .RelPermalink
If none of the above we look for an resource whose filepath contains `featured` or `cover` and use its .RelPermalink if found

Fixes #233
Fixes #407

Thanks to @sgharms @pmorch