### PR TITLE
Standardize featured_image logic

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,4 +1,4 @@
-{{ $featured_image := .Param "featured_image"}}
+{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
 {{ if $featured_image }}
   {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
   {{ $featured_image := (trim $featured_image "/") | absURL }}


### PR DESCRIPTION
Updates the site-header partial's featured_image logic to call the GetFeaturedImage partial so that it's consistent with the homepage and the page-header partial.

Closes #473
