### PR TITLE
Update build environment logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,18 +296,49 @@ Now enter [`localhost:1313`](http://localhost:1313/) in the address bar of your 
 
 ## Production
 
-To run in production (e.g. to have Google Analytics show up), run `HUGO_ENV=production` before your build command. For example:
+To run in production (e.g. to have Google Analytics show up), you must set the build environment name. The four options for setting the build environment name (ordered by priority) are:
 
-```
-HUGO_ENV=production hugo
-```
+1. The `HUGO_ENV` environment variable.
 
-Note: The above command will not work on Windows. If you are running a Windows OS, use the below command:
+    Examples:
 
-```
-set HUGO_ENV=production
-hugo
-```
+    **macOS/Linux**
+
+    ```bash
+    HUGO_ENV=production hugo
+    ```
+
+    **Windows Command shell**
+
+    ```bat
+    set HUGO_ENV=production
+    hugo
+    ```
+
+    **PowerShell**
+
+    ```powershell
+    $env:HUGO_ENV='production'
+    hugo
+    ```
+
+1. The `env` site config theme parameter, for example:
+
+    ```toml
+    [params]
+      env = "production"
+    ```
+
+1. Setting the `useHugoEnv` site config theme parameter to true, which will use the value of [`.Hugo.Environment`](https://gohugo.io/variables/hugo/) for the build environment name. This option is recommended if using [environment-specific config directories](https://gohugo.io/getting-started/configuration/#configuration-directory), such as for minifying only your production builds.
+
+    The default environment name for the `hugo server` command is `development`, and the default for the `hugo` build command is `production`. The environment name can be configured via the `--environment` flag, such as `hugo --environment test`.
+
+    ```toml
+    [params]
+      useHugoEnv = true
+    ```
+
+1. Use the default build environment name.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Now enter [`localhost:1313`](http://localhost:1313/) in the address bar of your 
 
 ## Production
 
-To run in production (e.g. to have Google Analytics show up), you must set the build environment name. The four options for setting the build environment name (ordered by priority) are:
+To run in production (e.g. to have Google Analytics show up), you must set the build environment name to `production`. The three options for setting the build environment name (ordered by priority) are:
 
 1. The `HUGO_ENV` environment variable.
 
@@ -337,8 +337,6 @@ To run in production (e.g. to have Google Analytics show up), you must set the b
     [params]
       useHugoEnv = true
     ```
-
-1. Use the default build environment name.
 
 ## Contributing
 

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -36,6 +36,8 @@ enableRobotsTXT = true
   background_color_class = "bg-black"
   featured_image = "/images/gohugo-default-sample-hero-image.jpg"
   recent_posts_number = 2
+  # Uncomment to use the value of .Hugo.Environment for defining the build environment
+  # useHugoEnv = true
 
 [[params.ananke_socials]]
 name = "twitter"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,3 +1,5 @@
+{{ $env := partial "func/GetEnvironmentName.html" . }}
+{{ $isProduction := partial "func/IsProduction.html" . }}
 <!DOCTYPE html>
 <html lang="{{ $.Site.LanguageCode | default "en" }}">
   <head>
@@ -8,8 +10,7 @@
     <meta name="viewport" content="width=device-width,minimum-scale=1">
     <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
     {{ hugo.Generator }}
-    {{/* NOTE: For Production make sure you add `HUGO_ENV="production"` before your build command */}}
-    {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
+    {{ if $isProduction }}
       <META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
     {{ else }}
       <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
@@ -34,13 +35,13 @@
     {{- template "_internal/schema.html" . -}}
     {{- template "_internal/twitter_cards.html" . -}}
 
-    {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
+    {{ if $isProduction }}
       {{ template "_internal/google_analytics_async.html" . }}
     {{ end }}
 	{{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}
   </head>
 
-  <body class="ma0 {{ $.Param "body_classes"  | default "avenir bg-near-white"}}{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">
+  <body class="ma0 {{ $.Param "body_classes"  | default "avenir bg-near-white"}}{{ with $env }} {{ . }}{{ end }}">
 
     {{ block "header" . }}{{ partial "site-header.html" .}}{{ end }}
     <main class="pb7" role="main">

--- a/layouts/partials/func/GetEnvironmentName.html
+++ b/layouts/partials/func/GetEnvironmentName.html
@@ -1,0 +1,35 @@
+{{/*
+  GetEnvironmentName
+
+  This partial returns either the configured or the default build environment
+  name.
+
+  The four options for setting the build environment name (ordered by priority)
+  are:
+  1. The "HUGO_ENV" environment variable.
+  2. The "env" site config theme parameter.
+  3. Setting the "useHugoEnv" site config theme parameter to true, which will
+     use the value of ".Hugo.Environment" for the build environment name.
+
+     The default environment name for the  "hugo server" command is
+     "development", and the default for the "hugo" build command is
+     "production". The environment name can be configured via the
+     "--environment" flag, such as "hugo --environment test".
+  4. Use the default build environment name.
+
+  @return build environment name.
+*/}}
+
+{{ $env := "development" }}
+{{ $site := site }}
+{{ $hugo := hugo }}
+
+{{ if (getenv "HUGO_ENV") }}
+  {{ $env = getenv "HUGO_ENV" }}
+{{ else if $site.Params.env }}
+  {{ $env = $site.Params.env }}
+{{ else if (eq $site.Params.useHugoEnv true) }}
+  {{ $env = $hugo.Environment }}
+{{ end }}
+
+{{ return $env }}

--- a/layouts/partials/func/IsProduction.html
+++ b/layouts/partials/func/IsProduction.html
@@ -9,7 +9,7 @@
 {{ $env := partial "func/GetEnvironmentName.html" . }}
 
 {{ if eq $env "production" }}
-  {{ $isProduction := true }}
+  {{ $isProduction = true }}
 {{ end }}
 
 {{ return $isProduction }}

--- a/layouts/partials/func/IsProduction.html
+++ b/layouts/partials/func/IsProduction.html
@@ -1,0 +1,15 @@
+{{/*
+  IsProduction
+
+  @return false, unless the build environment is set to production via one of
+  the methods supported in the func/GetEnvironment partial.
+*/}}
+
+{{ $isProduction := false }}
+{{ $env := partial "func/GetEnvironmentName.html" . }}
+
+{{ if eq $env "production" }}
+  {{ $isProduction := true }}
+{{ end }}
+
+{{ return $isProduction }}

--- a/layouts/partials/func/style/GetMainCSS.html
+++ b/layouts/partials/func/style/GetMainCSS.html
@@ -59,7 +59,7 @@ css asset directory we add to aforementioned slice */}}
   {{ $options := dict "enableSourceMap" true "precision" 6 }}
   {{ $style = $style | resources.ToCSS $options | minify }}
   {{/* We fingerprint in production for cache busting purposes */}}
-  {{ if eq (getenv "HUGO_ENV") "production" }}
+  {{ if (partial "func/IsProduction.html" .) }}
     {{ $style = $style | fingerprint }}
   {{ end }}
   {{/* We're ready to set returning variable with resulting resource */}}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
-# robotstxt.org - if ENV production variable is false robots will be disallowed.
-{{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
+# robotstxt.org - if the build is not configured for production, robots will be disallowed.
+{{ if (partial "func/IsProduction.html" .) }}
 Allow: /
 Sitemap: {{.Site.BaseURL}}/sitemap.xml
 {{ else }}


### PR DESCRIPTION
Closes #453
Relates to #457

* Adds GetEnvironmentName and IsProduction partial functions, which improve DRY
* Add prioritization for determining environment name, which favors the existing methods: the `HUGO_ENV` environment variable and site config `env` theme parameter
* Adds `useHugoEnv` theme parameter to use the value of `.Hugo.Environment` for the build environment name