### PR TITLE
Fix zh* translation

### DIFF
--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -11,7 +11,7 @@ other = "最近 {{.Title }}"
 other = "繼續閱讀"
 
 [whatsInThis]
-other = "更多關於 {{ .Type }}"
+other = "這個{{ .Type }}中有"
 
 [related]
 other = "相關內容"

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -11,7 +11,7 @@ other = "最近 {{.Title }}"
 other = "继续阅读"
 
 [whatsInThis]
-other = "这是什么 {{ .Type }}"
+other = "这个{{ .Type }}中有"
 
 [related]
 other = "相关內容"


### PR DESCRIPTION
The old translations was "What's this" instead of "What's in this"