### PR TITLE
Add German translation for taxonomyPageList

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -32,7 +32,7 @@ other = "Eine Email Adresse wird benötigt."
 other = "Senden"
 
 [taxonomyPageList]
-other = "Below you will find pages that utilize the taxonomy term “{{ .Title }}”"
+other = "Beiträge zum Thema “{{ .Title }}”"
 
 [readingTime]
 one = "Eine Minute"


### PR DESCRIPTION
The phrase was only present in English.