### PR TITLE
Use i18n string for taxonomy layout

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,10 +1,10 @@
 {{ define "main" }}
   <article class="cf pa3 pa4-m pa4-l">
     <div class="measure-wide-l center f4 lh-copy nested-copy-line-height nested-links nested-img {{ $.Param "text_color" | default "mid-gray" }}">
-      <p>Below you will find pages that utilize the taxonomy term “{{ .Title }}”</p>
+      <p>{{ i18n "taxonomyPageList" . }}</p>
     </div>
   </article>
-  <div class="mw8 center">    
+  <div class="mw8 center">
     <section class="flex-ns flex-wrap justify-around mt5">
       {{ range  .Pages }}
         <div class="relative w-100  mb4 bg-white">


### PR DESCRIPTION
This allows for overriding of the string (without overriding the whole
layout), such as
[here](https://github.com/scubbo/blogContent/commit/23240c3367164c9300eb8895a7837c7f07ff5b9c)