### PR TITLE
Improve Portuguese translation

### DIFF
--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -2,7 +2,7 @@
 other = "Mais"
 
 [allTitle]
-other = "Todo o {{.Title }}"
+other = "Ver mais {{.Title }}"
 
 [recentTitle]
 other = "{{.Title }} Recentes"
@@ -33,6 +33,14 @@ other = "Enviar"
 
 [taxonomyPageList]
 other = "Abaixo você encontrará as páginas que utilizam o termo de taxonomia “{{ .Title }}”"
+
+[readingTime]
+one = "Um minuto de leitura"
+other = "{{ .Count }} minutos de leitura"
+
+[wordCount]
+one = "Uma palavra"
+other = "{{ .Count }} palavras"
 
 [pageTitle]
 other = "{{ .Name }} página"


### PR DESCRIPTION
It doesn't make sense to use "Todo o", we get "Todo o Publicações", "Todo o Notícias" ou "Todo o Posts". 

"Ver mais" (See more) makes more sense, since it can be correctly used for whatever we call our posts in Portuguese. "Ver mais Publicações", "Ver mais Notícias" ou "Ver mais Posts".