### PR TITLE
Localize "By"

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -10,6 +10,9 @@ other = "Neuste {{.Title }}"
 [readMore]
 other = "weiterlesen"
 
+[by]
+other = "Von"
+
 [whatsInThis]
 other = "Was ist in dieser {{ .Type }}"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -10,6 +10,9 @@ other = "Recent {{.Title }}"
 [readMore]
 other = "read more"
 
+[by]
+other = "By"
+
 [whatsInThis]
 other = "What's in this {{ .Type }}"
 

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -10,6 +10,9 @@ other = "{{.Title }} recientes"
 [readMore]
 other = "Leer más"
 
+[by]
+other = "Por"
+
 [whatsInThis]
 other = "Qué hay en este {{ .Type }}"
 

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -10,6 +10,9 @@ other = "{{.Title }} récents"
 [readMore]
 other = "lire plus"
 
+[by]
+other = "Par"
+
 [whatsInThis]
 other = "Ce qui est dans {{ .Type }}"
 

--- a/i18n/it.toml
+++ b/i18n/it.toml
@@ -10,6 +10,9 @@ other = "Recenti {{.Title }}"
 [readMore]
 other = "leggi di più"
 
+[by]
+other = "Da"
+
 [whatsInThis]
 other = "Cosa c'è in {{ .Type }}"
 

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -10,6 +10,9 @@ other = "Nyeste {{.Title }}"
 [readMore]
 other = "Les mer"
 
+[by]
+other = "Av"
+
 [whatsInThis]
 other = "Innhold av {{ .Type }}"
 

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -10,6 +10,9 @@ other = "{{.Title }} Recentes"
 [readMore]
 other = "Leia mais"
 
+[by]
+other = "por"
+
 [whatsInThis]
 other = "O que há neste {{ .Type }}"
 

--- a/layouts/_default/by.html
+++ b/layouts/_default/by.html
@@ -1,0 +1,3 @@
+{{- if eq .Lang "de" "en" "es" "fr" "it" "no" "pt" -}}
+{{- i18n "by" -}}
+{{ end -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,13 +20,13 @@
       </h1>
       {{ with .Params.author | default .Site.Params.author }}
       <p class="tracked">
-          {{ i18n "by" }} <strong>
-          {{ if reflect.IsSlice . }}
-              {{ delimit . ", " | markdownify }}
-          {{else}}
-              {{ . | markdownify }}
-          {{ end }}
-          </strong>
+        {{ $.Render "by" }} <strong>
+        {{- if reflect.IsSlice . -}}
+            {{ delimit . ", " | markdownify }}
+        {{- else -}}
+            {{ . | markdownify }}
+        {{- end -}}
+        </strong>
       </p>
       {{ end }}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,7 +20,7 @@
       </h1>
       {{ with .Params.author | default .Site.Params.author }}
       <p class="tracked">
-          By <strong>
+          {{ i18n "by" }} <strong>
           {{ if reflect.IsSlice . }}
               {{ delimit . ", " | markdownify }}
           {{else}}


### PR DESCRIPTION
If an author is set the page will mention them with the with the "By" preposition which had never been localized. I've proceeded to add it for the languages I'm familiar with. 

If you've been mentioned in the following checklist, this means I identified you as the kind person(s) who initially or most recently updated the language's localization. Would you be kind enough to add you suggestion in the comments using this simple format: EN: `By` 

If you have any reservations, for example the preposition needs to agree with gender or number in the given language, please let me also know in the comments.

Thank you all!

- [ ] BG @foxbg 🙏 
- [x] DE: `Von`
- [x] EN: `By`
- [x] ES: `Por`
- [ ]  FI: @larihuttunen 🙏 
- [x] FR: `Par`
- [ ] HI: @neeraj9 🙏 
- [ ] HU: @winux1 🙏 
- [x] IT: `Da`
- [ ] JA: @ssatosays 🙏 
- [ ] NL: @eddex @johanv 🙏 
- [x] NO: @xaner4 🙏 
- [x] PT: `Por`
- [ ] RU: @eddex 🙏 
- [ ] SV: @theninth 🙏 
- [ ] TR: @evrifaessa 🙏 
- [ ] UK: @mivanchenko 🙏 


Fixes #528