### PR TITLE
Remove Section mention from single/page

### DIFF
--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -3,9 +3,6 @@
   <div class="flex-l mt2 mw8 center">
     <article class="center cf pv5 ph3 ph4-ns mw7">
       <header>
-        <p class="f6 b helvetica tracked">
-          {{ humanize .Section | upper  }}
-        </p>
         <h1 class="f1">
           {{ .Title }}
         </h1>


### PR DESCRIPTION
Fixes #522

Came to my attention that the section would never be useful. Pages are most often at the root of the content directory `/content/about.md`, so the section would be the homepage.

If the page sits in `about/staff.md` then the default type would be `about` and not `page` thus not picking up the `single/page.md`.

The current implementation will blindly print the name of the directory in which belong the page which makes it impossible to localize.