### PR TITLE
Add rel=me attribute to social links: fixes mastodon account metadata verification

### DIFF
--- a/layouts/partials/social-follow.html
+++ b/layouts/partials/social-follow.html
@@ -1,7 +1,7 @@
 {{ $socials := where (partialCached "func/socials/Get" "socials/Get") "follow" "!=" false }}
 <div class="ananke-socials">
   {{ range $socials }}
-    <a href="{{ .url }}" target="_blank" class="{{ .name }} ananke-social-link link-transition stackoverflow link dib z-999 pt3 pt0-l {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml1" "mr1" }}" title="{{ .label }} link" rel="noopener" aria-label="follow on {{ .label }}——Opens in a new window">
+    <a href="{{ .url }}" target="_blank" class="{{ .name }} ananke-social-link link-transition stackoverflow link dib z-999 pt3 pt0-l {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml1" "mr1" }}" title="{{ .label }} link" rel="me noopener" aria-label="follow on {{ .label }}——Opens in a new window">
       {{ with .icon }}
         <span class="icon">{{ . }}</span>
       {{ else }}


### PR DESCRIPTION
Adds rel=me attribute to social links
This fixes #417 about mastodon account metadata verification