### PR TITLE
Improve links for sitemap and taxonomies

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -7,13 +7,13 @@
   </article>
   <div class="mw8 center">
     <section class="ph4">
-      {{ range $key, $value := .Data.Terms }}
+      {{ range $term := .Data.Pages }}
         <h2 class="f1">
-          <a href="{{ "/" | relLangURL }}{{ $.Data.Plural | urlize }}/{{ $key | urlize }}" class="link blue hover-black">
-            {{ $.Data.Singular | humanize }}: {{ $key }}
+          <a href="{{ $term.RelPermalink }}" class="link blue hover-black">
+            {{ $.Data.Singular | humanize }}: {{ $term.LinkTitle }}
           </a>
         </h2>
-        {{ range $value.Pages }}
+        {{ range $term.Pages }}
           {{ .Render "summary" }}
         {{ end }}
       {{ end }}

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -1,6 +1,6 @@
 <footer class="{{ .Site.Params.background_color_class | default "bg-black" }} bottom-0 w-100 pa3" role="contentinfo">
   <div class="flex justify-between">
-  <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.BaseURL }}" >
+  <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ "/" | absURL }}" >
     &copy; {{ with .Site.Copyright | default .Site.Title }} {{ . | safeHTML }} {{ now.Format "2006"}} {{ end }}
   </a>
     <div>{{ partial "social-follow.html" . }}</div>

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -1,6 +1,6 @@
 <footer class="{{ .Site.Params.background_color_class | default "bg-black" }} bottom-0 w-100 pa3" role="contentinfo">
   <div class="flex justify-between">
-  <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ "/" | absURL }}" >
+  <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.Home.Permalink }}" >
     &copy; {{ with .Site.Copyright | default .Site.Title }} {{ . | safeHTML }} {{ now.Format "2006"}} {{ end }}
   </a>
     <div>{{ partial "social-follow.html" . }}</div>

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,8 +1,8 @@
 <ul class="pa0">
-  {{ range .Params.tags }}
+  {{ range .GetTerms "tags" }}
    <li class="list di">
-     <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}" class="link f5 grow no-underline br-pill ba ph3 pv2 mb2 dib black sans-serif">
-       {{- . -}}
+     <a href="{{ .RelPermalink }}" class="link f5 grow no-underline br-pill ba ph3 pv2 mb2 dib black sans-serif">
+       {{- .LinkTitle -}}
      </a>
    </li>
   {{ end }}

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,8 +1,8 @@
 User-agent: *
-# robotstxt.org - if ENV production variable is false robots will be disallowed.
-{{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
+{{/* robotstxt.org - if ENV production variable is false robots will be disallowed. */ -}}
+{{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  -}}
 Allow: /
-Sitemap: {{.Site.BaseURL}}/sitemap.xml
-{{ else }}
+Sitemap: {{ "/sitemap.xml" | absURL }}
+{{ else -}}
 Disallow: /
-{{ end }}
+{{ end -}}


### PR DESCRIPTION
This PR makes a few changes to improve the links generated by the theme templates:

1. use `absURL` to create the sitemap URL rather than concatenating with `.Site.BaseURL`. This avoids a non-canonical URL if BaseURL ends in a slash.
2. use `.GetTerms` to get a list of the tags for the page. This returns a list of page objects that know their URL.
3. use `.Data.Pages` to enumerate the terms in a taxonomy rather than `.Data.Terms`. Again, this lets Hugo generate the appropriate URL.

I noticed (2) and (3) in a Google search console report for my site, where the existing templates generate links without a trailing slash, resulting in a redirect. Letting Hugo generate the links itself avoids the problem. It also seems to work correctly with multi-lingual sites, after clicking around in the example site.

To test the example site, I modified its go.mod file to force it to use the in-tree version of the theme rather than downloading a second copy of the theme (which won't include any of the changes I'm trying to test). Looking at the git history, it seems the example site used to do this but it was reverted for some reason in ddf6a834. It's not clear from the commit message why that was done.