### PR TITLE
Add support for Google Analytics 4

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,7 +37,7 @@
     {{- template "_internal/twitter_cards.html" . -}}
 
     {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
-      {{ template "_internal/google_analytics_async.html" . }}
+      {{ template "_internal/google_analytics.html" . }}
     {{ end }}
 	{{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}
   </head>


### PR DESCRIPTION
This PR makes the following changes
- Replaces async GA template with `_internal/google_analytics.html`

## Context 
The [Hugo documentation](https://github.com/gohugoio/hugo/blob/ffbdcc75ab7d1d96219e84a20e53de9358fe5adf/docs/content/en/templates/internal.md?plain=1#L59) recommends using `_internal/google_analytics.html` for GA4.

closes https://github.com/theNewDynamic/gohugo-theme-ananke/issues/546

