### PR TITLE
Feature: Support rel="me" social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,20 @@ params:
     label: TND Twitter
 ```
 
+#### RelMe Verification
+
+If a user wants to use their social media links for [RelMeAuth](https://microformats.org/wiki/RelMeAuth) verification, they can set `verify: true` on the registered service.
+This form of social verification is used on platforms like [Mastodon](https://joinmastodon.org/).
+With `verify: true`, the social follow adds `rel="me"` to the generated link.
+
+```yaml
+params:
+  ananke_socials:
+  - name: mastodon
+    url: https://mastodon.social/@theNewDynamic
+    verify: true
+```
+
 #### Social Icons Customization
 
 On top of easily customizing the built-in services' label and color, user can overwrite their icon by adding an svg file at `/assets/ananke/socials` with a filename matching the service's name.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -39,3 +39,4 @@ enableRobotsTXT = true
 [[params.ananke_socials]]
 name = "twitter"
 url = "https://twitter.com/GoHugoIO"
+verify = false

--- a/layouts/partials/func/socials/Get.html
+++ b/layouts/partials/func/socials/Get.html
@@ -14,6 +14,7 @@
       String (.label)
       String (.color)?
       Bool (.share)?
+      Bool (.verify)?
   @uses
      - partial
 

--- a/layouts/partials/func/socials/GetRegisteredServices.html
+++ b/layouts/partials/func/socials/GetRegisteredServices.html
@@ -14,7 +14,7 @@
       String (.url)
       String (.label)?
       String (.color)?
-
+      Bool (.verify)?
 */}}
 
 {{ $registered_services := slice }}

--- a/layouts/partials/social-follow.html
+++ b/layouts/partials/social-follow.html
@@ -1,7 +1,7 @@
 {{ $socials := where (partialCached "func/socials/Get" "socials/Get") "follow" "!=" false }}
 <div class="ananke-socials">
   {{ range $socials }}
-    <a href="{{ .url }}" target="_blank" class="{{ .name }} ananke-social-link link-transition stackoverflow link dib z-999 pt3 pt0-l {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml1" "mr1" }}" title="{{ .label }} link" rel="noopener" aria-label="follow on {{ .label }}——Opens in a new window">
+    <a href="{{ .url }}" target="_blank" class="{{ .name }} ananke-social-link link-transition stackoverflow link dib z-999 pt3 pt0-l {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml1" "mr1" }}" title="{{ .label }} link" rel="{{ cond (eq .verify true) "me" "noopener" }}" aria-label="follow on {{ .label }}——Opens in a new window">
       {{ with .icon }}
         <span class="icon">{{ . }}</span>
       {{ else }}


### PR DESCRIPTION
- New social option `verify` which allows a social follow link to be used for RelMeAuth verification.
- Update social-follow.html partial to use `rel="me"` if the `.verify` option is set to `true`.
- Document the `.verify` value in partial functions.
- Update the example `config.toml` to use the verify option.
- Document `verify` option in README.md

Fixes #417 