### PR TITLE
layouts: add support for setting additional relations on social links

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ params:
 On top of easily customizing the built-in services' label and color, user can overwrite their icon by adding an svg file at `/assets/ananke/socials` with a filename matching the service's name.
 For example, in order to use your own GitHub icon, simply add an svg file at `/assets/ananke/socials/github.svg`
 
+#### Additional relations
+
+You can add extra relations to the social links via the `rel:` property. This can be used to assert ownership of the linked account as described in the [rel="me" mircroformat](https://microformats.org/wiki/rel-me).
+
+```yaml
+params:
+  ananke_socials:
+  - name: twitter
+    url: https://twitter.com/theNewDynamic
+    rel: me
+```
+
 #### Built-in Services
 Here is the list of built-in services. Those marked with an `*` are also part of the "Share" module.
 

--- a/layouts/partials/func/socials/Get.html
+++ b/layouts/partials/func/socials/Get.html
@@ -14,6 +14,7 @@
       String (.label)
       String (.color)?
       Bool (.share)?
+      String (.rel)?
   @uses
      - partial
 

--- a/layouts/partials/social-follow.html
+++ b/layouts/partials/social-follow.html
@@ -1,7 +1,7 @@
 {{ $socials := where (partialCached "func/socials/Get" "socials/Get") "follow" "!=" false }}
 <div class="ananke-socials">
   {{ range $socials }}
-    <a href="{{ .url }}" target="_blank" class="{{ .name }} ananke-social-link link-transition stackoverflow link dib z-999 pt3 pt0-l {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml1" "mr1" }}" title="{{ .label }} link" rel="noopener" aria-label="follow on {{ .label }}——Opens in a new window">
+    <a href="{{ .url }}" target="_blank" class="{{ .name }} ananke-social-link link-transition stackoverflow link dib z-999 pt3 pt0-l {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml1" "mr1" }}" title="{{ .label }} link" rel="noopener{{ with .rel }} {{ . }}{{ end }}" aria-label="follow on {{ .label }}——Opens in a new window">
       {{ with .icon }}
         <span class="icon">{{ . }}</span>
       {{ else }}


### PR DESCRIPTION
This is an attempt to allow setting rel="me" on social links in the page header/footer. I hadn't noticed #587 when writing this, so consider it an alternative proposal to fix the problem.

This PR adds a new `rel` attribute to services listed under `ananke_socials`. If set, it specifies additional relations that will be added to the corresponding social link. This should cover case of claiming ownership of a Mastodon account, while also handling any other relations the user might want to add:

```yaml
ananke_socials:
  - name: mastodon
    url: ....
    rel: me
```

While I'm just using a simple string property, it's possible to add multiple new relations by treating it as a space separated list (e.g. `rel: one two three`). When used, it adds to the existing `noopener` relation rather than replacing it.

Fixes #417