### PR TITLE
example site: set languageCode for french language

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -17,6 +17,7 @@ enableRobotsTXT = true
     contentDir = "content/en"
     # languageDirection = 'rtl' for Right-To-Left languages
   [languages.fr]
+    languageCode = "fr"
     title = "Ananke Fr"
     weight = 2
     contentDir = "content/fr"


### PR DESCRIPTION
When using the config from the Example site, the document language is not set correctly for french.:

```
<html lang="en-us">
```

The site's language code needs to be set explicitly to fix this, it seems.