### PR TITLE
Decrease the top margin a bit

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -60,7 +60,7 @@
       </div>
     </div>
 
-    <aside class="w-30-l mt6-l">
+    <aside class="w-30-l mt3-l">
       {{- partial "menu-contextual.html" . -}}
     </aside>
 


### PR DESCRIPTION
Decrease the top margin of the side panel on large displays from mt6 to mt3.

Especially having table of contents enabled (`toc: true`) the content of the side panel is not easily identified as such. Actually the TOC is almost off the screen.. :\

So less ideal. In my case people should detect the table of contents easier.

For reference, I'm using a 1920x1080 panel. 