### PR TITLE
Show how-to use the build-in hugo -e flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,12 @@ set HUGO_ENV=production
 hugo
 ```
 
+Alternatively, you can also run production build using:
+
+```
+hugo -e production
+```
+
 ## Contributing
 
 If you find a bug or have an idea for a feature, feel free to use the [issue tracker](https://github.com/theNewDynamic/gohugo-theme-ananke/issues) to let me know.


### PR DESCRIPTION
You don't need to set `HUGO_ENV`, you can use the built-in `-e` or `--environment` flag on the `hugo` command.