### PR TITLE
Support for dynamically localizing menus with i18n

### DIFF
--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -14,7 +14,7 @@
           {{ range .Site.Menus.main }}
           <li class="list f5 f4-ns fw4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
             <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
-              {{ .Name }}
+              {{ i18n .Identifier | default .Name}}
             </a>
           </li>
           {{ end }}

--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -14,7 +14,7 @@
           {{ range .Site.Menus.main }}
           <li class="list f5 f4-ns fw4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
             <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
-              {{ i18n .Identifier | default .Name}}
+              {{ i18n .Identifier | default .Name }}
             </a>
           </li>
           {{ end }}


### PR DESCRIPTION
This PR adds support for an i18n identifier for items in the main navigation. 

This is described in the [Multilingual menus](https://gohugo.io/content-management/multilingual/#multilingual-themes-support) section of the Hugo documentation.