### PR TITLE
Include authors meta tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -16,6 +16,15 @@
     {{ else }}
       <meta name="robots" content="noindex, nofollow">
     {{ end }}
+    {{ with .Params.author | default .Site.Params.author }}
+      <meta name="author" content = "
+        {{- if reflect.IsSlice . -}}
+          {{ delimit . ", " | plainify }}
+        {{- else -}}
+          {{ . | plainify }}
+        {{- end -}}
+      ">
+    {{ end }}
 
     {{ partial "site-style.html" . }}
     {{ partial "site-scripts.html" . }}


### PR DESCRIPTION
This patch includes a `<meta name="author" ...` tag. If there are multiple authors, their names will be comma-seperated.
