### PR TITLE
Use of .RelPermalink brokes the multilingual host functionality

### DIFF
--- a/layouts/partials/i18nlist.html
+++ b/layouts/partials/i18nlist.html
@@ -3,7 +3,7 @@
 <ul class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr0 ml3" "pl0 mr3" }}">
     {{ range .Translations }}
     <li class="list f5 f4-ns fw4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
-        <a class="hover-white no-underline white-90" href="{{ .RelPermalink }}">{{ .Lang }}</a>
+        <a class="hover-white no-underline white-90" href="{{ .Permalink }}">{{ .Lang }}</a>
     </li>
     {{ end}}
 </ul>


### PR DESCRIPTION
https://gohugo.io/content-management/multilingual/#configure-multilingual-multihost

this functionality needs to create the language links with .Permalink