### PR TITLE
Fix capitalization of single page section header for a11y

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,12 +7,12 @@
   {{ $section := .Site.GetPage "section" .Section }}
   <article class="flex-l flex-wrap justify-between mw8 center ph3">
     <header class="mt4 w-100">
-      <aside class="instapaper_ignoref b helvetica tracked">
+      <aside class="instapaper_ignoref b helvetica tracked ttu">
           {{/*
           CurrentSection allows us to use the section title instead of inferring from the folder.
           https://gohugo.io/variables/page/#section-variables-and-methods
           */}}
-        {{with .CurrentSection.Title }}{{. | upper }}{{end}}
+        {{ .CurrentSection.Title }}
       </aside>
       {{ partial "social-share.html" . }}
       <h1 class="f1 athelas mt3 mb1">


### PR DESCRIPTION
Currently `layouts/_default/single.html` uses `{{with .CurrentSection.Title }}{{. | upper }}{{end}}` to change the section title to ALL UPPERCASE.

This is bad for accessibility, because screen readers are likely to read POSTS as "pee oh ess tee ess".

The right thing to do if you want something to be displayed in all caps is to use CSS `text-transform`. This PR fixes the template to do that. Happily Tachyons has [a class for the purpose](http://tachyons.io/docs/typography/text-transform/), so the template code ends up being simpler.