### PR TITLE
Add missing "read more" link to summary.html

### DIFF
--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -9,5 +9,6 @@
     <div class="nested-links f5 lh-copy nested-copy-line-height">
       {{ .Summary }}
     </div>
+    <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
   </div>
 </div>

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -12,4 +12,5 @@
     <div class="nested-links f5 lh-copy nested-copy-line-height">
       {{ .Summary  }}
     </div>
+  <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
   </div>


### PR DESCRIPTION
The `summary.html` template is missing the "read more" link that's in `summary-with-image.html`. The headings on a summary.html page have nothing to indicate that they are clickable -- no color variation, no underlining -- so it looks like there's nothing more than the heading and summary.

This adds the missing "read more" link so people know there's an entire article/post to read.

(Edit: Also fixes the post-specific `summary.html`)