### PR TITLE
Access Disqus shortname from canonical location

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,16 @@ You may need to delete the line: `themesDir = "../.."`
 
 To enable comments, add following to your config file:
 
-- DISQUS: `disqusShortname = YOURSHORTNAME`
-- COMMENTO:
+- DISQUS:
+
+  ```toml
+  [services.disqus]
+    shortname = 'YOURSHORTNAME'
   ```
+
+- COMMENTO:
+
+  ```toml
   [params]
     commentoEnable = true
   ```

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -51,7 +51,7 @@
       {{- .Content -}}
       {{- partial "tags.html" . -}}
       <div class="mt6 instapaper_ignoref">
-      {{ if .Site.DisqusShortname }}
+      {{ if .Site.Config.Services.Disqus.Shortname }}
         {{ template "_internal/disqus.html" . }}
       {{ end }}
       {{ if .Site.Params.commentoEnable }}


### PR DESCRIPTION
Prepare for deprecation described [here](https://github.com/gohugoio/hugo/commit/2eca1b3cc1cd03fee40c0abcdc61dab1016c0475).

This is a backwards compatible change.

