### PR TITLE
 Contribution: fix hard-coded link to section #664 

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -55,6 +55,4 @@
     {{ end }}
   {{ end }}
 {{end}}
-    {{/*  {{ $section_name := index (.Site.Params.mainSections) 0 }}  */}}
-
     

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,55 +1,60 @@
 {{ define "main" }}
- <article class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy {{ $.Param "text_color" | default "mid-gray" }}">
-    {{ .Content }}
-  </article>
-  {{/* Define a section to pull recent posts from. For Hugo 0.20 this will default to the section with the most number of pages. */}}
-  {{ $mainSections := .Site.Params.mainSections | default (slice "post") }}
-  {{/* Create a variable with that section to use in multiple places. */}}
-  {{ $section := where .Site.RegularPages "Section" "in" $mainSections }}
-  {{/* Check to see if the section is defined for ranging through it */}}
-  {{ $section_count := len $section }}
-  {{ if ge $section_count 1 }}
+  <article class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy {{ $.Param "text_color" | default "mid-gray" }}">
+      {{ .Content }}
+    </article>
+    {{/* Define a section to pull recent posts from. For Hugo 0.20 this will default to the section with the most number of pages. */}}
+    {{ $mainSections := .Site.Params.mainSections | default (slice "post") }}
+    
+    {{/* Check to see if the section is defined for ranging through it */}}
+    {{range ($mainSections)}}
     {{/* Derive the section name  */}}
-    {{ $section_name := index (.Site.Params.mainSections) 0 }}
+    {{ $section_name := . }}
+    {{/* Create a variable with that section to use in multiple places. */}}
+    {{ $section := where $.Site.RegularPages "Section" "in" $section_name }}
+    {{ $section_count := len $section }}
+    {{ if ge $section_count 1 }}
+      <div class="pa3 pa4-ns w-100 w-70-ns center">
+        {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
+        {{ with $.Site.GetPage "section" $section_name }}
+            <h1 class="flex-none">
+              {{ $.Param "recent_copy" | default (i18n "recentTitle" .) }}
+            </h1>
+          {{ end }}
 
-    <div class="pa3 pa4-ns w-100 w-70-ns center">
-      {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
-       {{ with .Site.GetPage "section" $section_name }}
-          <h1 class="flex-none">
-            {{ $.Param "recent_copy" | default (i18n "recentTitle" .) }}
-          </h1>
-        {{ end }}
+        {{ $n_posts := $.Param "recent_posts_number" | default 3 }}
 
-      {{ $n_posts := $.Param "recent_posts_number" | default 3 }}
-
-      <section class="w-100 mw8">
-        {{/* Range through the first $n_posts items of the section */}}
-        {{ range (first $n_posts $section) }}
-          <div class="relative w-100 mb4">
-            {{ .Render "summary-with-image" }}
-          </div>
-        {{ end }}
-      </section>
-
-      {{ if ge $section_count (add $n_posts 1) }}
-      <section class="w-100">
-        <h1 class="f3">{{ i18n "more" }}</h1>
-        {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first" on the outside */}}
-        {{ range (first 4 (after $n_posts $section))  }}
-          <h2 class="f5 fw4 mb4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml3" "mr3" }}">
-            <a href="{{ .RelPermalink }}" class="link black dim">
-              {{ .Title }}
-            </a>
-          </h2>
-        {{ end }}
-
-        {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
-        {{ with .Site.GetPage "section" $section_name }}
-          <a href="{{ .RelPermalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
-        {{ end }}
+        <section class="w-100 mw8">
+          {{/* Range through the first $n_posts items of the section */}}
+          {{ range (first $n_posts $section) }}
+            <div class="relative w-100 mb4">
+              {{ .Render "summary-with-image" }}
+            </div>
+          {{ end }}
         </section>
-      {{ end }}
 
-      </div>
+        {{ if ge $section_count (add $n_posts 1) }}
+        <section class="w-100">
+          <h1 class="f3">{{ i18n "more" }}</h1>
+          {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first" on the outside */}}
+          {{ range (first 4 (after $n_posts $section))  }}
+            <h2 class="f5 fw4 mb4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "ml3" "mr3" }}">
+              <a href="{{ .RelPermalink }}" class="link black dim">
+                {{ .Title }}
+              </a>
+            </h2>
+          {{ end }}
+
+          {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
+          {{ with .Site.GetPage "section" $section_name }}
+            <a href="{{ .RelPermalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
+          {{ end }}
+          </section>
+        {{ end }}
+
+        </div>
+    {{ end }}
   {{ end }}
-{{ end }}
+{{end}}
+    {{/*  {{ $section_name := index (.Site.Params.mainSections) 0 }}  */}}
+
+    


### PR DESCRIPTION
#664  describes it.

https://github.com/theNewDynamic/gohugo-theme-ananke/blob/c086834f0ebfa39b8b6b0cfed010588a6907a91c/layouts/index.html#L13C31-L13C31

At the moment, only the first mainsection will be shown in the index.

I changed it so that the mainsections will be iterated with "range $mainsections".
This allows that multiple sections are possible and can be displayed.