### PR TITLE
Limit footer to bottom

### DIFF
--- a/assets/ananke/css/_styles.css
+++ b/assets/ananke/css/_styles.css
@@ -18,3 +18,13 @@
 .nested-links a{
   overflow-wrap: break-word;
 }
+
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+footer {
+  margin-top: auto;
+}


### PR DESCRIPTION
Hello everyone!

I also discovered what is already topic in https://github.com/theNewDynamic/gohugo-theme-ananke/issues/502 and wanted to fix this problem:

When the content of a page is so small that the full page is smaller than the view-port the footer is not at the bottom.

With those little changes the page will be at least the size of the view-port and the space between content and footer is automatically a fitting margin at the top of the footer.

Same idea was also mentioned by https://github.com/Altonss