### PR TITLE
Fix Custom CSS - Width of text rendered

### DIFF
--- a/assets/ananke/css/custom.css
+++ b/assets/ananke/css/custom.css
@@ -1,0 +1,11 @@
+p {
+  text-align: left !important;
+}
+body {
+  max-width: none; /* Removes the maximum width constraint */
+}
+
+article {
+  max-width: 100%; /* Use the full width of the parent container */
+  margin: 0 auto; /* Center the content if needed */
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,7 @@
 module:
   hugoVersion:
     min: "0.84.0"
+params:
+  custom_css:
+    - custom.css
+  text_color: black


### PR DESCRIPTION
 restart your Hugo server, and see if the changes take effect. If the problem persists, inspect the rendered HTML and CSS using browser developer tools to identify any conflicting styles. Adjust your custom CSS accordingly.