### PR TITLE
Feature/menu footer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sethgecko13/gohugo-theme-ananke
+module github.com/theNewDynamic/gohugo-theme-ananke
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/theNewDynamic/gohugo-theme-ananke
+module github.com/sethgecko13/gohugo-theme-ananke
 
 go 1.14

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -3,6 +3,17 @@
   <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.Home.Permalink }}" >
     &copy; {{ with .Site.Copyright | default .Site.Title }} {{ . | safeHTML }} {{ now.Format "2006"}} {{ end }}
   </a>
+      {{ if .Site.Menus.footer}}
+        <ul class="{{ cond (eq $.Site.Language.LanguageDirection "rtl") "pr0 ml3" "pl0 mr3" }}">
+          {{ range .Site.Menus.footer}}
+          <li class="list f5 f4-ns fw4 dib {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
+            <a class="hover-white no-underline white-90" href="{{ .URL }}" title="{{ i18n "pageTitle" . }}">
+              {{ .Name }}
+            </a>
+          </li>
+          {{ end }}
+        </ul>
+      {{ end }}
     <div>{{ partial "social-follow.html" . }}</div>
   </div>
 </footer>


### PR DESCRIPTION
The gohugo manual says Hugo supports menus.footer (https://gohugo.io/content-management/menus/#define-in-site-configuration) e.g. for terms and conditions, privacy policy, etc.

This pull request updates the site-footer.html to support menus.footer.