### PR TITLE
Fix issue where hugo fails with error: to no such template "_internal/google_analytics_async.html"

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -37,7 +37,7 @@
     {{- template "_internal/twitter_cards.html" . -}}
 
     {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
-      {{ template "_internal/google_analytics_async.html" . }}
+      {{ template "_internal/google_analytics.html" . }}
     {{ end }}
 	{{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}
   </head>


### PR DESCRIPTION
Fix issue where hugo fails with error: to no such template "_internal/google_analytics_async.html"