### PR TITLE
Center post body horizontally if there is no toc nor related blocks

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,8 +4,10 @@
 {{ end }}
 
 {{ define "main" }}
+  {{- $related_content := .RegularPages.Related . -}}
+  {{- $needs_aside := or .Params.toc $related_content -}}
   {{ $section := .Site.GetPage "section" .Section }}
-  <article class="flex-l flex-wrap justify-between mw8 center ph3">
+  <article class="flex-l flex-wrap justify-between {{ if $needs_aside }}mw8{{ else }}mw7{{ end }} center ph3">
     <header class="mt4 w-100">
       <aside class="instapaper_ignoref b helvetica tracked ttu">
           {{/*
@@ -29,6 +31,7 @@
         </strong>
       </p>
       {{ end }}
+      {{- end -}}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
       {{ if not .Date.IsZero }}
       <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>
@@ -47,7 +50,7 @@
         <span class="f6 mv4 dib tracked"> - {{ i18n "wordCount" .WordCount }} </span>
       {{ end }}
     </header>
-    <div class="nested-copy-line-height lh-copy {{ $.Param "post_content_classes"  | default "serif"}} f4 nested-links {{ $.Param "text_color" | default "mid-gray" }} {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl4-l" "pr4-l" }} w-two-thirds-l">
+    <div class="nested-copy-line-height lh-copy {{ $.Param "post_content_classes"  | default "serif"}} f4 nested-links {{ $.Param "text_color" | default "mid-gray" }} {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl4-l" "pr4-l" }} {{ if $needs_aside }}w-two-thirds-l{{ else }}w-100-l{{ end }}">
       {{- .Content -}}
       {{- partial "tags.html" . -}}
       <div class="mt6 instapaper_ignoref">
@@ -59,10 +62,11 @@
       {{ end }}
       </div>
     </div>
-
+    {{- if $needs_aside -}}
     <aside class="w-30-l mt6-l">
       {{- partial "menu-contextual.html" . -}}
     </aside>
+    {{- end -}}
 
   </article>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -31,7 +31,6 @@
         </strong>
       </p>
       {{ end }}
-      {{- end -}}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
       {{ if not .Date.IsZero }}
       <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>


### PR DESCRIPTION
If there is no table of contents or related contents block defined the post page layout still leaves horizontal room for them to the right of the main content block. This, along _"measure"_ results in the post body to be artificially shifted to the left.

This PR changes that to center the body horizontally in the screen if there is no need for such a right side aside tag.

Sample using the example site. Screenshots taken on a 1792 x 1120 desktop display:

Before:

![](https://github.com/theNewDynamic/gohugo-theme-ananke/assets/40661/c0d95bfd-70c3-49ba-9049-772c028e65b0)

After:

![](https://github.com/theNewDynamic/gohugo-theme-ananke/assets/40661/6d5db784-5237-45ba-bfe9-d850bf0cc533)
