### PR TITLE
refactor: Simplify lang attribute in html element

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.LanguageCode | default site.Language.Lang  }}" {{- with partialCached "func/GetLanguageDirection" "GetLanguageDirection" }} dir="{{ . }}" {{- end }}>
+<html lang="{{ site.Language.LanguageCode }}" {{- with partialCached "func/GetLanguageDirection" "GetLanguageDirection" }} dir="{{ . }}" {{- end }}>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">


### PR DESCRIPTION
As of Hugo v0.122.4, these are equivalent:

```
{{ site.LanguageCode | default site.Language.Lang  }}
{{ site.Language.LanguageCode }}
```
See <https://gohugo.io/methods/site/language/#methods>