### PR TITLE
Add missing params on ananke.social.follow

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -42,7 +42,7 @@ featured_image_class = "cover bg-top"
 cover_dimming_class = "bg-black-60"
 recent_posts_number = 3
 
-[ananke.social.follow]
+[params.ananke.social.follow]
 new_window_icon = false # show a little "opens in new window" icon next to the link
 networks = [
   "facebook",


### PR DESCRIPTION
Add missing `params` prefix on `params.ananke.social.follow` when used in config.toml or hugo.toml.

