### PR TITLE
Fix social share cache

### DIFF
--- a/layouts/partials/social/share.html
+++ b/layouts/partials/social/share.html
@@ -19,7 +19,7 @@
   {{/* This here is an ugly workaround for GoHugo's missing sortByArray feature.
     Let's cache it so it does not take away too much time.
     PS: It's also a couple of years old, so maybe there is a better solution by now. */}}
-  {{- $setups = partials.IncludeCached "func/sortNetworks.html" (dict "networks" $networks "setups" $setups) "social-follow" -}}
+  {{- $setups = partials.IncludeCached "func/sortNetworks.html" (dict "networks" $networks "setups" $setups) "social-share" -}}
 
   <div id="sharing" class="mt3 ananke-socials">
     {{- range $setups -}}


### PR DESCRIPTION
Do NOT use the same cache name for social _share_ and social _follow_..

This will never work of course.