### PR TITLE
Do not cache share links

### DIFF
--- a/layouts/partials/social/share.html
+++ b/layouts/partials/social/share.html
@@ -34,7 +34,7 @@
         {{/* @todo notification into CLI that a network is configured but not supported */}}
       {{- end -}}
       {{- $options := (dict "context" page "setup" $setup) }}
-      {{- $href := partial "func/getShareLink.html" $options $options -}}
+      {{- $href := partial "func/getShareLink.html" $options -}}
       <a href="{{ $href }}"
         class="ananke-social-link {{ $setup.slug }} no-underline"
         title="{{ $label }}" aria-label="{{ $label }}"

--- a/layouts/partials/social/share.html
+++ b/layouts/partials/social/share.html
@@ -34,7 +34,7 @@
         {{/* @todo notification into CLI that a network is configured but not supported */}}
       {{- end -}}
       {{- $options := (dict "context" page "setup" $setup) }}
-      {{- $href := partialCached "func/getShareLink.html" $options $options -}}
+      {{- $href := partial "func/getShareLink.html" $options $options -}}
       <a href="{{ $href }}"
         class="ananke-social-link {{ $setup.slug }} no-underline"
         title="{{ $label }}" aria-label="{{ $label }}"


### PR DESCRIPTION
You can't just cache the share links, that will result into every blog post having the same URL.

Just use `partial` on the getShareLink.html. So now each post will show the correct URL to share the post via social media or alike.