### PR TITLE
Add transform.Plainify to the summary body content of the share links

### DIFF
--- a/layouts/partials/social/share.html
+++ b/layouts/partials/social/share.html
@@ -66,7 +66,7 @@
   {{- $setup := .setup -}}
   {{- $separator := "&" -}}
   {{- $title := $context.Title | transform.HTMLEscape -}}
-  {{- $description := $context.Summary | transform.HTMLEscape -}}
+  {{- $description := $context.Summary | transform.Plainify | transform.HTMLEscape -}}
   {{- $permalink := $context.Permalink | transform.HTMLEscape -}}
   {{- with $setup.separator -}}
     {{- $separator = . -}}


### PR DESCRIPTION
You definitely want to **add Plainify transformer first**, because the body content will become a HTML encoding mess. I left `HTMLEscape` there as well, just be sure for security reasons. But if you want, I can remove the second transformer.

Like a tweet on X will look like this:

![image](https://github.com/user-attachments/assets/73ab37b0-decc-47a4-8bbd-cf43cbef1641)


After implementing `transform.Plainify`, it will look much better:

![image](https://github.com/user-attachments/assets/962ba515-72ae-4b46-827f-2c477358d065)

(ignore the red, I don't have X premium pro blabla, it's red because I hit the max limit of chars)
