### PR TITLE
Fixes #794 - add show_recent_posts parameter to stop showing recent posts on index

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -1,3 +1,6 @@
+[ananke]
+show_recent_posts = true # show recent posts on the homepage
+
 [ananke.social]
 icon_path = "ananke/socials/%s.svg"
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,7 +4,7 @@
     </article>
     {{/* Define a section to pull recent posts from. For Hugo 0.20 this will default to the section with the most number of pages. */}}
     {{ $mainSections := .Site.Params.mainSections | default (slice "post") }}
-    {{ $show_recent_posts := .Site.Params.show_recent_posts | default (true) }}
+    {{ $show_recent_posts := site.Params.ananke.show_recent_posts }}
     
     {{/* Check to see if the section is defined for ranging through it */}}
     {{range ($mainSections)}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -4,6 +4,7 @@
     </article>
     {{/* Define a section to pull recent posts from. For Hugo 0.20 this will default to the section with the most number of pages. */}}
     {{ $mainSections := .Site.Params.mainSections | default (slice "post") }}
+    {{ $show_recent_posts := .Site.Params.show_recent_posts | default (true) }}
     
     {{/* Check to see if the section is defined for ranging through it */}}
     {{range ($mainSections)}}
@@ -12,7 +13,7 @@
     {{/* Create a variable with that section to use in multiple places. */}}
     {{ $section := where $.Site.RegularPages "Section" "in" $section_name }}
     {{ $section_count := len $section }}
-    {{ if ge $section_count 1 }}
+    {{ if and ($show_recent_posts) (ge $section_count 1) }}
       <div class="pa3 pa4-ns w-100 w-70-ns center">
         {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
         {{ with $.Site.GetPage "section" $section_name }}


### PR DESCRIPTION
<!---

Add the issue number that is discussed and fixed by this PR (In the form
`Closes #123`). If this PR doesn't fix an issue, remove the line below. This will
also lead to us not treating this PR as an important one. It might be closed
without a review.

If there is no issue associated with this PR and you are not a maintainer of
this repository, your PR might be closed without a review.

-->

Closes #794

You can no longer set `recent_posts_number = 0` because in current hugo versions `{{ $n_posts := $.Param "recent_posts_number" | default 3 }}` will default to three if recent_posts_number is 0. This used to work a couple of versions back, I am assuming this is not a regression but rather wanted behavior in hugo -- so I introduce a new parameter (boolean) `show_recent_posts` to enable(default) or disable recent posts on index.



<!---

Explain what this PR does and what existing problem it solves. If this PR is a
work in progress, please prefix the title with [WIP].

-->

<!--

Make sure that the code is readable and well-documented. If you have added new
functionality, please add the necessary documentation.
If testing of the new functionality is possible, please add tests.

-->
