### PR TITLE
Support reading_speed language param in single.html

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -43,7 +43,14 @@
           3) A page front matter value is set `show_reading_time = true`
         */}}
       {{ if (or (eq (.Param "show_reading_time") true) (eq $section.Params.show_reading_time true) )}}
-        <span class="f6 mv4 dib tracked"> - {{ i18n "readingTime" .ReadingTime }} </span>
+        {{ $readingTime := .ReadingTime }}
+
+        {{ with .Site.Params.reading_speed }}
+          {{ $readingTime = div (float $.WordCount) . }}
+          {{ $readingTime = math.Ceil $readingTime }}
+        {{ end }}
+
+        <span class="f6 mv4 dib tracked"> - {{ i18n "readingTime" (int $readingTime) }} </span>
         <span class="f6 mv4 dib tracked"> - {{ i18n "wordCount" .WordCount }} </span>
       {{ end }}
     </header>


### PR DESCRIPTION
<!---

Add the issue number that is discussed and fixed by this PR (In the form
`Closes #123`). If this PR doesn't fix an issue, remove the line below. This will
also lead to us not treating this PR as an important one. It might be closed
without a review.

If there is no issue associated with this PR and you are not a maintainer of
this repository, your PR might be closed without a review.

-->


<!---

Explain what this PR does and what existing problem it solves. If this PR is a
work in progress, please prefix the title with [WIP].

-->

This PR makes it possible to configure the reading speed in specific languages by adding a configuration like the one in the https://gohugo.io/methods/page/readingtime/ method page

example configuration that will be supported:
```toml
[languages.en.params]
reading_speed = 256
```

It doesn't necessarily solve an important problem because you can just override the theme's single.html file to achieve the same result, but maybe it would be nice to support reading_speed configuration out of the box.

<!--

Make sure that the code is readable and well-documented. If you have added new
functionality, please add the necessary documentation.
If testing of the new functionality is possible, please add tests.

-->
