### PR TITLE
Remove hard-coded text-color from recent posts entries. 

### DIFF
--- a/layouts/_default/summary-with-image.html
+++ b/layouts/_default/summary-with-image.html
@@ -1,6 +1,6 @@
 {{ $featured_image := partial "func/GetFeaturedImage.html" . }}
 <article class="bb b--black-10">
-  <div class="db pv4 ph3 ph0-l no-underline dark-gray">
+  <div class="db pv4 ph3 ph0-l no-underline">
     <div class="flex flex-column flex-row-ns">
       {{ if $featured_image }}
           {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}

--- a/layouts/partials/summary-with-image.html
+++ b/layouts/partials/summary-with-image.html
@@ -3,7 +3,7 @@ You should replace it with '.Render "summary-with-image"' as the use of this par
 More info here: https://github.com/theNewDynamic/gohugo-theme-ananke/releases/tag/v2.8.1` }}
 {{ $featured_image := partial "func/GetFeaturedImage.html" . }}
 <article class="bb b--black-10">
-  <div class="db pv4 ph3 ph0-l no-underline dark-gray">
+  <div class="db pv4 ph3 ph0-l no-underline">
     <div class="flex flex-column flex-row-ns">
       {{ if $featured_image }}
           {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}


### PR DESCRIPTION
The old implementation directly set the text color `dark-gray` which conflicts with many of the background colors the user can set with the `background_color_class` param. Since the similar param `background_clases` is honored in this object, so should the similar params `post_content_closesses` and/or `text_color` as would otherwise apply. 