### PR TITLE
Fix Hungarian spelling of e-mail address

### DIFF
--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -20,13 +20,13 @@ other = "Ajánlott cikkek"
 other = "Név"
 
 [emailAddress]
-other = "E-mail cím"
+other = "E-mail-cím"
 
 [message]
 other = "Üzenet"
 
 [emailRequiredNote]
-other = "E-mail cím megadása kötelező."
+other = "E-mail-cím megadása kötelező."
 
 [send]
 other = "Küldés"


### PR DESCRIPTION
The grammatical rules for spelling „e-mail-cím” has changed with the 12th edition of AkH. (Akadémiai helyesírási szabályzat), released in September 2015. It basically says that „cím” (address) must be appended to „e-mail” with a hyphen.

Here is the specific rule that applies:
https://helyesiras.mta.hu/helyesiras/default/akh12#140

Here are some articles those explain why Rule #140 applies to the spelling „e-mail-cím”: https://helyesiras.mta.hu/helyesiras/blog/show/kijott-az-1-3-7-es-verzio https://e-nyelv.hu/2016-09-04/e-mail-cim-e-mail-fiok/

While this new way of spelling has been around for almost a decade now, as I see its adoption is very slow: most people still use the old „e-mail cím” form, which is now incorrect. This just makes it more important to use the new spelling wherever possible.