### PR TITLE
Remove call to css.Sass

### DIFF
--- a/layouts/partials/func/style/GetMainCSS.html
+++ b/layouts/partials/func/style/GetMainCSS.html
@@ -68,7 +68,7 @@ css asset directory we (unless condition below) add to aforementioned slice */}}
 
   {{/* We then use toCSS to add sourceMap and minify */}}
   {{ $options := dict "enableSourceMap" true "precision" 6 }}
-  {{ $style = $style | css.Sass $options | resources.Minify }}
+  {{ $style := resources.Get "css/main.css" }}
   {{/* We fingerprint in production for cache busting purposes */}}
   {{ if hugo.IsProduction }}
     {{ $style = $style | resources.Fingerprint }}

--- a/layouts/partials/func/style/GetMainCSS.html
+++ b/layouts/partials/func/style/GetMainCSS.html
@@ -68,7 +68,7 @@ css asset directory we (unless condition below) add to aforementioned slice */}}
 
   {{/* We then use toCSS to add sourceMap and minify */}}
   {{ $options := dict "enableSourceMap" true "precision" 6 }}
-  {{ $style := resources.Get "css/main.css" }}
+  {{ $style := resources.Get "ananke/css/_styles.css" }}
   {{/* We fingerprint in production for cache busting purposes */}}
   {{ if hugo.IsProduction }}
     {{ $style = $style | resources.Fingerprint }}


### PR DESCRIPTION
There is no associated issue. The css.Sass doesn't seem to exist anymore - my change seems to fix this. This could be an incorrect approach.