### PR TITLE
feat: support self-hosted Commento via config param

### DIFF
--- a/layouts/partials/commento.html
+++ b/layouts/partials/commento.html
@@ -1,2 +1,7 @@
+{{ if or .Site.Params.commentoEnable .Site.Params.commentoUrl }}
 <div id="commento"></div>
-<script defer src="https://cdn.commento.io/js/commento.js"></script>
+<script
+  defer
+  src="{{ with .Site.Params.commentoUrl }}{{ . }}{{ else }}https://cdn.commento.io{{ end }}/js/commento.js"
+></script>
+{{ end }}


### PR DESCRIPTION

## Feature: Support self-hosted Commento in Ananke

### Description

This PR adds support for self-hosted Commento instances in the Ananke theme.
Currently, Ananke always loads Commento from `https://cdn.commento.io`, ignoring any custom configuration. With this change, users can specify their own Commento endpoint via `hugo.toml`.

---

### Changes

* Updated `layouts/partials/commento.html` to read `commentoUrl` from site params.
* If `commentoUrl` is defined, it will be used as the script source.
* If not, it falls back to the default `https://cdn.commento.io`.

Example configuration in `hugo.toml`:

```toml
commentoEnable = true
commentoUrl = "https://mydomain.com:8080"
```

---

### Benefits

* Backward compatible with existing behavior.
* Enables users to self-host Commento.
* Simple and low-maintenance change.

---

### Testing

* Verified locally with self-hosted Commento.
* Works as expected on my website  `http://220303.work` .

<img width="1896" height="948" alt="屏幕截图 2025-09-27 223606" src="https://github.com/user-attachments/assets/67610903-2d65-4b5c-b9b4-2743564a7a56" />
